### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library to control Grove - RTC DS1307.
 paragraph=Arduino library to control Grove - RTC DS1307.
-category=device
+category=Timing
 url=https://github.com/Seeed-Studio/RTC_DS1307
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'device' in library Grove - RTC DS1307 is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format