### PR TITLE
Added RAM access functions, removed overloaded begin() function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,2 @@
+[submodule "."]
+	url = https://github.com/kgmossey/RTC_DS1307.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,2 +1,0 @@
-[submodule "."]
-	url = https://github.com/kgmossey/RTC_DS1307.git

--- a/DS1307.cpp
+++ b/DS1307.cpp
@@ -40,9 +40,25 @@ uint8_t DS1307::bcdToDec(uint8_t val) {
     return ((val / 16 * 10) + (val % 16));
 }
 
+/**
+ * \brief          Start the I2C port
+ */
 void DS1307::begin() {
     Wire.begin();
 }
+
+#ifndef Arduino_h
+/**
+ * \brief          The function to start the I2C port with specified pins
+ *                 
+ * \param SDA      The pin number which is used as SDA pin
+ * \param SCL      The pin number which is used as SCL pin
+ *
+ */
+void DS1307::begin(uint16_t SDA ,uint16_t SCL) {
+    Wire.begin(SDA,SCL);
+}
+#endif
 
 /*Function: The clock timing will start */
 void DS1307::startClock(void) {      // set the ClockHalt bit low to start the rtc
@@ -86,7 +102,7 @@ void DS1307::getTime() {
     year       = bcdToDec(Wire.read());
 }
 /*******************************************************************/
-/*Frunction: Write the time that includes the date to the RTC chip */
+/*Function: Write the time that includes the date to the RTC chip */
 void DS1307::setTime() {
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);
@@ -99,21 +115,53 @@ void DS1307::setTime() {
     Wire.write(decToBcd(year));
     Wire.endTransmission();
 }
+
+/**
+ * \brief          Set the time
+ *
+ * \param _hour    Hour between 0-23
+ * \param _minute  Minute between 0-59
+ * \param _second  Second between 0-59
+ *
+ */
 void DS1307::fillByHMS(uint8_t _hour, uint8_t _minute, uint8_t _second) {
     // assign variables
     hour = _hour;
     minute = _minute;
     second = _second;
 }
+
+/**
+ * \brief          Set the date 
+ *
+ * \param _year    Year: 2000-2099
+ * \param _month   Month: 1-12
+ * \param _day     Day: 1-31
+ *
+ */
 void DS1307::fillByYMD(uint16_t _year, uint8_t _month, uint8_t _day) {
     year = _year - 2000;
     month = _month;
     dayOfMonth = _day;
 }
+
+/**
+ * \brief          Sets the day of week. The increments at midnight.
+ *
+ * \param _dow     MON, TUE, WED, THU, FRI, SAT, SUN 
+ *
+ */
 void DS1307::fillDayOfWeek(uint8_t _dow) {
     dayOfWeek = _dow;
 }
 
+/**
+ * \brief          Save the contents of the RAM buffer to the DS1307
+ *                 
+ * \param _addr    The zero-index memory address (0-55)
+ * \param _value   The 8 bit value to store
+ *
+ */
 void DS1307::setRamAddress(uint8_t _addr, uint8_t _value) {
     uint8_t address = _addr + DS1307_RAM_OFFSET;
 
@@ -125,6 +173,9 @@ void DS1307::setRamAddress(uint8_t _addr, uint8_t _value) {
 
 }
 
+/**
+ * \brief          Save the contents of the RAM buffer to the DS1307
+ */
 void DS1307::setRam(){
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
     Wire.write(0x08);
@@ -134,6 +185,12 @@ void DS1307::setRam(){
     Wire.endTransmission();
 }
 
+/**
+ * \brief          Get the contents of a specific address
+ *
+ * \param _addr    The address to retrieve
+ *
+ */
 uint8_t DS1307::getRamAddress(uint8_t _addr) {
     uint8_t address = _addr + DS1307_RAM_OFFSET;
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
@@ -145,6 +202,9 @@ uint8_t DS1307::getRamAddress(uint8_t _addr) {
     return ram[_addr];
 }
 
+/**
+ * \brief          Retrieve the contents of RAM to the ram buffer
+ */
 void DS1307::getRam() {
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
     Wire.write(0x08);
@@ -156,6 +216,9 @@ void DS1307::getRam() {
     }
 }
 
+/**
+ * \brief          Returns whether or not the clock is started
+ */
 bool DS1307::isStarted(){
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);

--- a/DS1307.cpp
+++ b/DS1307.cpp
@@ -44,17 +44,6 @@ void DS1307::begin() {
     Wire.begin();
 }
 
-/**
- * \brief          The functio to start the I2C port with specified pins
- *                 
- * \param SDA      The pin number which is used as SDA pin
- * \param SCL      The pin number which is used as SCL pin
- *
- */
-void DS1307::begin(uint16_t SDA ,uint16_t SCL) {
-    Wire.begin(SDA,SCL);
-}
-
 /*Function: The clock timing will start */
 void DS1307::startClock(void) {      // set the ClockHalt bit low to start the rtc
     Wire.beginTransmission(DS1307_I2C_ADDRESS);
@@ -125,3 +114,52 @@ void DS1307::fillDayOfWeek(uint8_t _dow) {
     dayOfWeek = _dow;
 }
 
+void DS1307::setRamAddress(uint8_t _addr, uint8_t _value) {
+    uint8_t address = _addr + DS1307_RAM_OFFSET;
+
+    ram[_addr] = _value;
+    Wire.beginTransmission(DS1307_I2C_ADDRESS);
+    Wire.write(address);
+    Wire.write(_value);
+    Wire.endTransmission();
+
+}
+
+void DS1307::setRam(){
+    Wire.beginTransmission(DS1307_I2C_ADDRESS);
+    Wire.write(0x08);
+    for (uint8_t pos = 0; pos < 55; ++pos) {
+        Wire.write(ram[pos]);
+    }
+    Wire.endTransmission();
+}
+
+uint8_t DS1307::getRamAddress(uint8_t _addr) {
+    uint8_t address = _addr + DS1307_RAM_OFFSET;
+    Wire.beginTransmission(DS1307_I2C_ADDRESS);
+    Wire.write(address);
+    Wire.endTransmission();
+
+    Wire.requestFrom(DS1307_I2C_ADDRESS, 1);
+    ram[_addr] = Wire.read();
+    return ram[_addr];
+}
+
+void DS1307::getRam() {
+    Wire.beginTransmission(DS1307_I2C_ADDRESS);
+    Wire.write(0x08);
+    Wire.endTransmission();
+
+    Wire.requestFrom(DS1307_I2C_ADDRESS, 1);
+    for (uint8_t pos = 0; pos < 55; ++pos) {
+        ram[pos] = Wire.read();
+    }
+}
+
+bool DS1307::isStarted(){
+    Wire.beginTransmission(DS1307_I2C_ADDRESS);
+    Wire.write((uint8_t)0x00);
+    Wire.endTransmission();
+    Wire.requestFrom(DS1307_I2C_ADDRESS, 1);
+    return !(bool)(Wire.read() & 0x80);       // bit 7 (sart/stop bit) = clock started    
+}

--- a/DS1307.h
+++ b/DS1307.h
@@ -34,6 +34,7 @@
 #include <Arduino.h>
 
 #define DS1307_I2C_ADDRESS 0x68
+#define DS1307_RAM_OFFSET 0x08
 
 #define MON 1
 #define TUE 2
@@ -50,7 +51,6 @@ class DS1307 {
 
   public:
     void begin();
-    void begin(uint16_t SDA ,uint16_t SCL);
     void startClock(void);
     void stopClock(void);
     void setTime(void);
@@ -58,6 +58,11 @@ class DS1307 {
     void fillByHMS(uint8_t _hour, uint8_t _minute, uint8_t _second);
     void fillByYMD(uint16_t _year, uint8_t _month, uint8_t _day);
     void fillDayOfWeek(uint8_t _dow);
+    void setRamAddress(uint8_t _addr, uint8_t _value);
+    void setRam();
+    uint8_t getRamAddress(uint8_t _addr);
+    void getRam();
+    bool isStarted();
     uint8_t second;
     uint8_t minute;
     uint8_t hour;
@@ -65,6 +70,7 @@ class DS1307 {
     uint8_t dayOfMonth;
     uint8_t month;
     uint16_t year;
+    uint8_t ram[56];
 };
 
 #endif

--- a/DS1307.h
+++ b/DS1307.h
@@ -51,6 +51,9 @@ class DS1307 {
 
   public:
     void begin();
+#ifndef Arduino_h
+    void begin(uint16_t SDA ,uint16_t SCL);
+#endif
     void startClock(void);
     void stopClock(void);
     void setTime(void);


### PR DESCRIPTION
Bug fix: The Wire.h in the ESP32 library has the ability to set the SDA and SCL pins, but the Arduino Wire.h does not. Anyone trying to use this on an Arduino will get the "no matching function for call to 'TwoWire::begin..." as mentioned in the one issue on this library. I've removed that function so that it will compile properly on Arduino/AVR chips as well as ESP32. When the Arduino library is updated we can replace this function (which is super cool).

Feature add: I've added functions to read and write to RAM. The functions are fairly intuitive, I think.

void getRam() reads the contents of the DS1307 chip into a variable called "ram" which is publicly accessible.
void setRam() writes the contents of "ram" to the DS1307 chip.

If you only need to read/write an address, you can individually set each address to a specific 8 bit value (this saves time over reading/writing the entire ram buffer):

void setRamAddress(uint8_t _addr, uint8_t _value) sets a specific address (_addr) to a value (_value). It also updates the ram buffer.
uint8_t getRamAddress(uint8_t _addr) returns the value at a specific address (_addr)

RAM addresses are 0 indexed.